### PR TITLE
feat: add blob proof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ blst = "0.3.11"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ blst = "0.3.11"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
-sha2 = "0.10.8"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,6 +1,6 @@
 use crate::{
     bls::{FiniteFieldError, Fr, Scalar, P1},
-    kzg::{Commitment, Setup, Proof, Polynomial},
+    kzg::{Commitment, Polynomial, Proof, Setup},
     math::BitReversalPermutation,
 };
 
@@ -56,7 +56,11 @@ impl<const N: usize> Blob<N> {
         Commitment::from(lincomb)
     }
 
-    pub fn proof<const G1: usize, const G2: usize>(&self, commitment: Commitment, setup: impl AsRef<Setup<G1, G2>>) -> Proof {
+    pub fn proof<const G1: usize, const G2: usize>(
+        &self,
+        commitment: Commitment,
+        setup: impl AsRef<Setup<G1, G2>>,
+    ) -> Proof {
         let poly = Polynomial(self.elements.clone());
         let challenge = self.challenge(commitment);
         let (_, proof) = poly.prove(challenge, setup);
@@ -67,7 +71,7 @@ impl<const N: usize> Blob<N> {
         let domain = b"FSBLOBVERIFY_V1_";
         let degree = (N as u128).to_be_bytes();
 
-        let comm = commitment.as_ref().compress();
+        let comm = commitment.as_ref().serialize();
 
         let mut data = Vec::with_capacity(8 + 16 + Commitment::BYTES + Self::BYTES);
         data.extend_from_slice(domain);

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -6,10 +6,11 @@ use std::{
 use blst::{
     blst_bendian_from_scalar, blst_fp, blst_fr, blst_fr_add, blst_fr_eucl_inverse,
     blst_fr_from_scalar, blst_fr_from_uint64, blst_fr_mul, blst_fr_sub, blst_p1, blst_p1_add,
-    blst_p1_affine, blst_p1_affine_in_g1, blst_p1_deserialize, blst_p1_from_affine, blst_p1_mult,
-    blst_p2, blst_p2_affine, blst_p2_affine_in_g2, blst_p2_deserialize, blst_p2_from_affine,
-    blst_scalar, blst_scalar_fr_check, blst_scalar_from_bendian, blst_scalar_from_fr,
-    blst_scalar_from_uint64, blst_uint64_from_fr, BLST_ERROR, blst_p1_serialize, blst_p2_serialize, blst_p2_compress, blst_p1_compress,
+    blst_p1_affine, blst_p1_affine_in_g1, blst_p1_compress, blst_p1_deserialize,
+    blst_p1_from_affine, blst_p1_mult, blst_p2, blst_p2_affine, blst_p2_affine_in_g2,
+    blst_p2_deserialize, blst_p2_from_affine, blst_scalar, blst_scalar_fr_check,
+    blst_scalar_from_bendian, blst_scalar_from_fr, blst_scalar_from_uint64, blst_uint64_from_fr,
+    BLST_ERROR,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -329,7 +330,7 @@ impl P1 {
         }
     }
 
-    pub fn compress(&self) -> [u8; Self::BYTES] {
+    pub fn serialize(&self) -> [u8; Self::BYTES] {
         let mut out = [0; Self::BYTES];
         unsafe {
             blst_p1_compress(out.as_mut_ptr(), &self.element);

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -3,14 +3,15 @@ use std::{
     ops::{Add, Div, Mul, Sub},
 };
 
+use alloy_primitives::{FixedBytes, U256};
 use blst::{
     blst_bendian_from_scalar, blst_fp, blst_fr, blst_fr_add, blst_fr_eucl_inverse,
     blst_fr_from_scalar, blst_fr_from_uint64, blst_fr_mul, blst_fr_sub, blst_p1, blst_p1_add,
     blst_p1_affine, blst_p1_affine_in_g1, blst_p1_compress, blst_p1_deserialize,
     blst_p1_from_affine, blst_p1_mult, blst_p2, blst_p2_affine, blst_p2_affine_in_g2,
     blst_p2_deserialize, blst_p2_from_affine, blst_scalar, blst_scalar_fr_check,
-    blst_scalar_from_bendian, blst_scalar_from_fr, blst_scalar_from_uint64, blst_uint64_from_fr,
-    BLST_ERROR,
+    blst_scalar_from_bendian, blst_scalar_from_fr, blst_scalar_from_uint64, blst_sha256,
+    blst_uint64_from_fr, BLST_ERROR,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -204,6 +205,26 @@ impl Fr {
 
         out = out * tmp;
         out
+    }
+
+    pub(crate) fn hash_to(data: impl AsRef<[u8]>) -> Self {
+        let mut hash = [0; Self::BYTES];
+        unsafe {
+            blst_sha256(
+                hash.as_mut_ptr(),
+                data.as_ref().as_ptr(),
+                data.as_ref().len(),
+            );
+        }
+
+        let modulus = U256::from_be_bytes(Fr::MODULUS.to_be_bytes());
+        let hash = U256::from_be_bytes(hash);
+        let hash = hash.reduce_mod(modulus);
+
+        let hash: [u8; Fr::BYTES] = hash.to_be_bytes();
+        let hash = FixedBytes::from(hash);
+
+        Self::from_be_bytes(hash).unwrap()
     }
 }
 

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -217,11 +217,11 @@ impl Fr {
             );
         }
 
-        let modulus = U256::from_be_bytes(Fr::MODULUS.to_be_bytes());
+        let modulus = U256::from_be_bytes(Self::MODULUS.to_be_bytes());
         let hash = U256::from_be_bytes(hash);
         let hash = hash.reduce_mod(modulus);
 
-        let hash: [u8; Fr::BYTES] = hash.to_be_bytes();
+        let hash: [u8; Self::BYTES] = hash.to_be_bytes();
         let hash = FixedBytes::from(hash);
 
         Self::from_be_bytes(hash).unwrap()

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -187,8 +187,8 @@ impl Fr {
 
     pub fn pow(&self, power: impl AsRef<Self>) -> Self {
         let power = Scalar::from(power).to_be_bytes();
-        let mut power = alloy_primitives::U256::from_be_bytes(power);
-        let one = alloy_primitives::U256::from(1u64);
+        let mut power = U256::from_be_bytes(power);
+        let one = U256::from(1u64);
 
         let mut out = *self;
         let mut tmp = Self::ONE;

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -180,6 +180,12 @@ impl Commitment {
     }
 }
 
+impl AsRef<P1> for Commitment {
+    fn as_ref(&self) -> &P1 {
+        &self.0
+    }
+}
+
 impl From<P1> for Commitment {
     fn from(point: P1) -> Self {
         Self(point)
@@ -196,6 +202,12 @@ impl Proof {
         P1::from_be_bytes(bytes)
             .map(Self)
             .map_err(|err| Error::Bls(bls::Error::from(err)))
+    }
+}
+
+impl AsRef<P1> for Proof {
+    fn as_ref(&self) -> &P1 {
+        &self.0
     }
 }
 
@@ -234,7 +246,7 @@ mod tests {
     #[derive(serde::Deserialize, serde::Serialize)]
     struct ComputeKzgProofUnchecked {
         input: ComputeKzgProofInputUnchecked,
-        output: Option<(FixedBytes<{ P1::BYTES }>, FixedBytes<{ Fr::BYTES }>)>,
+        output: Option<(FixedBytes<{ Proof::BYTES }>, FixedBytes<{ Fr::BYTES }>)>,
     }
 
     struct ComputeKzgProofInput {
@@ -260,7 +272,7 @@ mod tests {
     #[derive(serde::Deserialize, serde::Serialize)]
     struct BlobToCommitmentUnchecked {
         input: BlobToCommitmentInputUnchecked,
-        output: Option<FixedBytes<{ P1::BYTES }>>,
+        output: Option<FixedBytes<{ Commitment::BYTES }>>,
     }
 
     struct BlobToCommitmentInput {
@@ -271,6 +283,35 @@ mod tests {
         pub fn from_unchecked(unchecked: BlobToCommitmentInputUnchecked) -> Result<Self, ()> {
             let blob = Blob::from_slice(unchecked.blob).map_err(|_| ())?;
             Ok(Self { blob })
+        }
+    }
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct ComputeBlobKzgProofInputUnchecked {
+        blob: Bytes,
+        commitment: Bytes,
+    }
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct ComputeBlobKzgProofUnchecked {
+        input: ComputeBlobKzgProofInputUnchecked,
+        output: Option<FixedBytes<{ Proof::BYTES }>>,
+    }
+
+    struct ComputeBlobKzgProofInput {
+        blob: Blob<FIELD_ELEMENTS_PER_BLOB>,
+        commitment: Commitment,
+    }
+
+    impl ComputeBlobKzgProofInput {
+        pub fn from_unchecked(unchecked: ComputeBlobKzgProofInputUnchecked) -> Result<Self, ()> {
+            let blob = Blob::from_slice(unchecked.blob).map_err(|_| ())?;
+            if unchecked.commitment.len() != Commitment::BYTES {
+                return Err(());
+            }
+            let commitment = FixedBytes::<{Commitment::BYTES}>::from_slice(&unchecked.commitment);
+            let commitment = Commitment::from_be_bytes(commitment).map_err(|_| ())?;
+            Ok(Self { blob, commitment })
         }
     }
 
@@ -318,6 +359,34 @@ mod tests {
 
                     assert_eq!(eval, expected_eval);
                     assert_eq!(proof.0, expected_proof);
+                }
+                Err(_) => {
+                    assert!(case.output.is_none());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn compute_blob_kzg_proof() {
+        let setup = setup();
+        let setup = Arc::new(setup);
+
+        let files = consensus_spec_test_files("compute_blob_kzg_proof");
+
+        for file in files {
+            let reader = BufReader::new(file);
+            let case: ComputeBlobKzgProofUnchecked = serde_yaml::from_reader(reader).unwrap();
+
+            match ComputeBlobKzgProofInput::from_unchecked(case.input) {
+                Ok(input) => {
+                    let proof = case.output.unwrap();
+                    let proof = P1::from_be_bytes(proof).unwrap();
+                    let expected_proof= Proof::from(proof);
+
+                    let proof = input.blob.proof(input.commitment, setup.clone());
+
+                    assert_eq!(proof, expected_proof);
                 }
                 Err(_) => {
                     assert!(case.output.is_none());

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -168,7 +168,7 @@ impl<const N: usize> Polynomial<N> {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Commitment(P1);
+pub struct Commitment(pub(crate) P1);
 
 impl Commitment {
     pub const BYTES: usize = P1::BYTES;
@@ -180,12 +180,6 @@ impl Commitment {
     }
 }
 
-impl AsRef<P1> for Commitment {
-    fn as_ref(&self) -> &P1 {
-        &self.0
-    }
-}
-
 impl From<P1> for Commitment {
     fn from(point: P1) -> Self {
         Self(point)
@@ -193,7 +187,7 @@ impl From<P1> for Commitment {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Proof(P1);
+pub struct Proof(pub(crate) P1);
 
 impl Proof {
     pub const BYTES: usize = P1::BYTES;
@@ -202,12 +196,6 @@ impl Proof {
         P1::deserialize(bytes)
             .map(Self)
             .map_err(|err| Error::Bls(bls::Error::from(err)))
-    }
-}
-
-impl AsRef<P1> for Proof {
-    fn as_ref(&self) -> &P1 {
-        &self.0
     }
 }
 

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -309,8 +309,8 @@ mod tests {
             if unchecked.commitment.len() != Commitment::BYTES {
                 return Err(());
             }
-            let commitment = FixedBytes::<{Commitment::BYTES}>::from_slice(&unchecked.commitment);
-            let commitment = Commitment::from_be_bytes(commitment).map_err(|_| ())?;
+            let commitment = FixedBytes::<{ Commitment::BYTES }>::from_slice(&unchecked.commitment);
+            let commitment = Commitment::deserialize(commitment).map_err(|_| ())?;
             Ok(Self { blob, commitment })
         }
     }
@@ -381,8 +381,8 @@ mod tests {
             match ComputeBlobKzgProofInput::from_unchecked(case.input) {
                 Ok(input) => {
                     let proof = case.output.unwrap();
-                    let proof = P1::from_be_bytes(proof).unwrap();
-                    let expected_proof= Proof::from(proof);
+                    let proof = P1::deserialize(proof).unwrap();
+                    let expected_proof = Proof::from(proof);
 
                     let proof = input.blob.proof(input.commitment, setup.clone());
 


### PR DESCRIPTION
add `proof` method to `Blob` and consensus spec tests for "compute blob KZG proof".