### PR TITLE
feat: add batch blob proof verification

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -43,12 +43,12 @@ impl<const N: usize> Blob<N> {
     ) -> Commitment {
         assert_eq!(G1, N);
 
-        // TODO: optimize w/ pippenger
-        let mut lincomb = P1::INF;
         let g1_lagrange = BitReversalPermutation::new(setup.as_ref().g1_lagrange.as_slice());
-        for i in 0..N {
-            lincomb = lincomb + (g1_lagrange[i] * Scalar::from(self.elements[i]));
-        }
+        let lincomb = P1::lincomb(
+            g1_lagrange
+                .iter()
+                .zip(self.elements.iter().map(Scalar::from)),
+        );
 
         Commitment::from(lincomb)
     }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -76,7 +76,7 @@ impl<const N: usize> Blob<N> {
         kzg::verify(proof, commitment, challenge, eval, setup)
     }
 
-    fn challenge(&self, commitment: &Commitment) -> Fr {
+    pub(crate) fn challenge(&self, commitment: &Commitment) -> Fr {
         let domain = b"FSBLOBVERIFY_V1_";
         let degree = (N as u128).to_be_bytes();
 
@@ -93,4 +93,29 @@ impl<const N: usize> Blob<N> {
 
         Fr::hash_to(data)
     }
+}
+
+pub fn verify_batch<const N: usize, const G1: usize, const G2: usize>(
+    blobs: impl AsRef<[Blob<N>]>,
+    commitments: impl AsRef<[Commitment]>,
+    proofs: impl AsRef<[Proof]>,
+    setup: impl AsRef<Setup<G1, G2>>,
+) -> bool {
+    assert_eq!(N, G1);
+    assert_eq!(blobs.as_ref().len(), commitments.as_ref().len());
+    assert_eq!(commitments.as_ref().len(), proofs.as_ref().len());
+
+    let mut challenges = Vec::with_capacity(blobs.as_ref().len());
+    let mut evaluations = Vec::with_capacity(blobs.as_ref().len());
+
+    for i in 0..blobs.as_ref().len() {
+        let poly = Polynomial(blobs.as_ref()[i].elements.clone());
+        let challenge = blobs.as_ref()[i].challenge(&commitments.as_ref()[i]);
+        let eval = poly.evaluate(challenge);
+
+        challenges.push(challenge);
+        evaluations.push(eval);
+    }
+
+    kzg::verify_batch(proofs, commitments, challenges, evaluations, setup)
 }

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -201,12 +201,6 @@ impl From<P1> for Proof {
     }
 }
 
-impl AsRef<P1> for Proof {
-    fn as_ref(&self) -> &P1 {
-        &self.0
-    }
-}
-
 pub fn verify<const G1: usize, const G2: usize>(
     proof: Proof,
     commitment: Commitment,
@@ -251,9 +245,15 @@ pub fn verify_batch<const G1: usize, const G2: usize>(
         rpowers.push(r.pow(Fr::from(i as u64)));
     }
 
-    let proof_lincomb = P1::lincomb(proofs.as_ref().iter().zip(rpowers.iter().map(Scalar::from)));
+    let proof_lincomb = P1::lincomb(
+        proofs
+            .as_ref()
+            .iter()
+            .map(|p| p.0)
+            .zip(rpowers.iter().map(Scalar::from)),
+    );
     let proof_z_lincomb = P1::lincomb(
-        proofs.as_ref().iter().zip(
+        proofs.as_ref().iter().map(|p| p.0).zip(
             points
                 .as_ref()
                 .iter()

--- a/src/math.rs
+++ b/src/math.rs
@@ -47,6 +47,13 @@ where
             phantom: PhantomData,
         }
     }
+
+    pub(crate) fn iter(&self) -> BitReversalPermutationIter<T> {
+        BitReversalPermutationIter {
+            inner: self.elements.as_ref(),
+            index: 0,
+        }
+    }
 }
 
 impl<T, S> Index<usize> for BitReversalPermutation<T, S>
@@ -59,6 +66,29 @@ where
         let log = self.elements.as_ref().len().ilog2();
         let index = index.reverse_bits() >> (usize::BITS - log);
         &self.elements.as_ref()[index]
+    }
+}
+
+pub struct BitReversalPermutationIter<'a, T> {
+    inner: &'a [T],
+    index: usize,
+}
+
+impl<'a, T> Iterator for BitReversalPermutationIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.inner.len() {
+            return None;
+        }
+
+        let log = self.inner.len().ilog2();
+        let index = self.index.reverse_bits() >> (usize::BITS - log);
+        let next = &self.inner[index];
+
+        self.index += 1;
+
+        Some(next)
     }
 }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -63,8 +63,7 @@ where
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
-        let log = self.elements.as_ref().len().ilog2();
-        let index = index.reverse_bits() >> (usize::BITS - log);
+        let index = bit_reversal_permutation_index(index, self.elements.as_ref().len());
         &self.elements.as_ref()[index]
     }
 }
@@ -82,14 +81,17 @@ impl<'a, T> Iterator for BitReversalPermutationIter<'a, T> {
             return None;
         }
 
-        let log = self.inner.len().ilog2();
-        let index = self.index.reverse_bits() >> (usize::BITS - log);
+        let index = bit_reversal_permutation_index(self.index, self.inner.len());
         let next = &self.inner[index];
 
         self.index += 1;
 
         Some(next)
     }
+}
+
+fn bit_reversal_permutation_index(index: usize, len: usize) -> usize {
+    index.reverse_bits() >> (usize::BITS - len.ilog2())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
add `blob::verify_batch` function and consensus spec tests for "verify blob KZG proof batch".