### PR TITLE
feat: finite field scalar mult for group elements

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -45,11 +45,7 @@ impl<const N: usize> Blob<N> {
         assert_eq!(G1, N);
 
         let g1_lagrange = BitReversalPermutation::new(setup.as_ref().g1_lagrange.as_slice());
-        let lincomb = P1::lincomb(
-            g1_lagrange
-                .iter()
-                .zip(self.elements.iter().map(Scalar::from)),
-        );
+        let lincomb = P1::lincomb(g1_lagrange.iter().zip(self.elements.iter()));
 
         Commitment::from(lincomb)
     }

--- a/src/kzg/poly.rs
+++ b/src/kzg/poly.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bls::{Fr, Scalar, P1},
+    bls::{Fr, P1},
     math::{self, BitReversalPermutation},
 };
 
@@ -72,7 +72,7 @@ impl<const N: usize> Polynomial<N> {
                 }
                 quotient
             };
-            quotient_poly.push(Scalar::from(quotient));
+            quotient_poly.push(quotient);
         }
 
         let g1_lagrange = BitReversalPermutation::new(setup.as_ref().g1_lagrange.as_slice());


### PR DESCRIPTION
implement `Mul<Fr>` operation for group elements `P1` and `P2` and substitute for `Mul<Scalar>`.

resolves #21.