### PR TITLE
refactor: tie setup G1 const to blob/poly const

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -38,22 +38,20 @@ impl<const N: usize> Blob<N> {
         Ok(Self { elements })
     }
 
-    pub(crate) fn commitment<const G1: usize, const G2: usize>(
+    pub(crate) fn commitment<const G2: usize>(
         &self,
-        setup: impl AsRef<Setup<G1, G2>>,
+        setup: impl AsRef<Setup<N, G2>>,
     ) -> Commitment {
-        assert_eq!(G1, N);
-
         let g1_lagrange = BitReversalPermutation::new(setup.as_ref().g1_lagrange.as_slice());
         let lincomb = P1::lincomb(g1_lagrange.iter().zip(self.elements.iter()));
 
         Commitment::from(lincomb)
     }
 
-    pub(crate) fn proof<const G1: usize, const G2: usize>(
+    pub(crate) fn proof<const G2: usize>(
         &self,
         commitment: &Commitment,
-        setup: impl AsRef<Setup<G1, G2>>,
+        setup: impl AsRef<Setup<N, G2>>,
     ) -> Proof {
         let poly = Polynomial(&self.elements);
         let challenge = self.challenge(commitment);

--- a/src/kzg/poly.rs
+++ b/src/kzg/poly.rs
@@ -37,12 +37,11 @@ impl<'a, const N: usize> Polynomial<'a, N> {
     }
 
     /// returns a `Proof` for the evaluation of the polynomial at `point`.
-    pub(crate) fn prove<const G1: usize, const G2: usize>(
+    pub(crate) fn prove<const G2: usize>(
         &self,
         point: Fr,
-        setup: impl AsRef<Setup<G1, G2>>,
+        setup: impl AsRef<Setup<N, G2>>,
     ) -> (Fr, Proof) {
-        assert_eq!(G1, N);
         let roots = math::roots_of_unity::<N>();
         let roots = BitReversalPermutation::new(roots);
 


### PR DESCRIPTION
use the `N` const generic parameter of `Blob` and `Polynomial` for the `G1` const generic parameter of `Setup`.