### PR TITLE
chore: rm TODO for blob to polynomial conversion

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -15,8 +15,6 @@ impl From<FiniteFieldError> for Error {
     }
 }
 
-// TODO: a blob and a polynomial are essentially the same as written. if that holds, then there
-// ought to be a zero-cost conversion between blob and polynomial.
 #[derive(Clone, Debug)]
 pub struct Blob<const N: usize> {
     pub(crate) elements: Box<[Fr; N]>,


### PR DESCRIPTION
remove `TODO` for zero-cost `Blob` to `Polynomial` conversion.

the `TODO` was addressed by #26.