### PR TITLE
refactor: various AsRef adjustments

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -36,11 +36,8 @@ impl<const N: usize> Blob<N> {
         Ok(Self { elements })
     }
 
-    pub(crate) fn commitment<const G2: usize>(
-        &self,
-        setup: impl AsRef<Setup<N, G2>>,
-    ) -> Commitment {
-        let g1_lagrange = BitReversalPermutation::new(setup.as_ref().g1_lagrange.as_slice());
+    pub(crate) fn commitment<const G2: usize>(&self, setup: &Setup<N, G2>) -> Commitment {
+        let g1_lagrange = BitReversalPermutation::new(setup.g1_lagrange.as_slice());
         let lincomb = P1::lincomb(g1_lagrange.iter().zip(self.elements.iter()));
 
         Commitment::from(lincomb)
@@ -49,7 +46,7 @@ impl<const N: usize> Blob<N> {
     pub(crate) fn proof<const G2: usize>(
         &self,
         commitment: &Commitment,
-        setup: impl AsRef<Setup<N, G2>>,
+        setup: &Setup<N, G2>,
     ) -> Proof {
         let poly = Polynomial(&self.elements);
         let challenge = self.challenge(commitment);

--- a/src/kzg/poly.rs
+++ b/src/kzg/poly.rs
@@ -10,12 +10,8 @@ pub(crate) struct Polynomial<'a, const N: usize>(pub(crate) &'a [Fr; N]);
 
 impl<'a, const N: usize> Polynomial<'a, N> {
     /// evaluates the polynomial at `point`.
-    pub(crate) fn evaluate<const G2: usize>(
-        &self,
-        point: Fr,
-        setup: impl AsRef<Setup<N, G2>>,
-    ) -> Fr {
-        let roots = BitReversalPermutation::new(setup.as_ref().roots_of_unity.as_slice());
+    pub(crate) fn evaluate<const G2: usize>(&self, point: Fr, setup: &Setup<N, G2>) -> Fr {
+        let roots = BitReversalPermutation::new(setup.roots_of_unity.as_slice());
 
         // if `point` is a root of a unity, then we have the evaluation available
         for i in 0..N {
@@ -35,19 +31,15 @@ impl<'a, const N: usize> Polynomial<'a, N> {
         }
 
         // barycentric evaluation scalar multiplication
-        let term = (point.pow(Fr::from(N as u64)) - Fr::ONE) / Fr::from(N as u64);
+        let term = (point.pow(&Fr::from(N as u64)) - Fr::ONE) / Fr::from(N as u64);
         eval * term
     }
 
     /// returns a `Proof` for the evaluation of the polynomial at `point`.
-    pub(crate) fn prove<const G2: usize>(
-        &self,
-        point: Fr,
-        setup: impl AsRef<Setup<N, G2>>,
-    ) -> (Fr, Proof) {
-        let roots = BitReversalPermutation::new(setup.as_ref().roots_of_unity.as_slice());
+    pub(crate) fn prove<const G2: usize>(&self, point: Fr, setup: &Setup<N, G2>) -> (Fr, Proof) {
+        let roots = BitReversalPermutation::new(setup.roots_of_unity.as_slice());
 
-        let eval = self.evaluate(point, &setup);
+        let eval = self.evaluate(point, setup);
 
         // compute the quotient polynomial
         //
@@ -76,8 +68,8 @@ impl<'a, const N: usize> Polynomial<'a, N> {
             quotient_poly.push(quotient);
         }
 
-        let g1_lagrange = BitReversalPermutation::new(setup.as_ref().g1_lagrange.as_slice());
-        let lincomb = P1::lincomb(g1_lagrange.iter().zip(quotient_poly));
+        let g1_lagrange = BitReversalPermutation::new(setup.g1_lagrange.as_slice());
+        let lincomb = P1::lincomb(g1_lagrange.iter().zip(quotient_poly.iter()));
 
         (eval, Proof(lincomb))
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -10,7 +10,7 @@ fn primitive_root_of_unity<const ORDER: usize>() -> Fr {
     let power = Fr::MAX / order;
     let primitive = Fr::from(PRIMITIVE_ROOT_OF_UNITY);
 
-    primitive.pow(power)
+    primitive.pow(&power)
 }
 
 pub fn roots_of_unity<const ORDER: usize>() -> [Fr; ORDER] {
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn primitive_root_of_unity() {
         let primitive = super::primitive_root_of_unity::<4096>();
-        let primitive_inv = primitive.pow(Fr::from(4095));
+        let primitive_inv = primitive.pow(&Fr::from(4095));
         assert_eq!(primitive * primitive_inv, Fr::ONE);
     }
 }


### PR DESCRIPTION
make various adjustments with respect to `AsRef` implementations and function parameters.

changes include the following:

* replace some `impl AsRef` function parameters with `&` reference
* modify `AsRef` implementations for BLS field/group elements to target inner `blst` types
* add linear combination variant `P1::lincomb_owned` whose arguments are owned