### PR TITLE
refactor: make crypto domain for challenge const

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -67,13 +67,13 @@ impl<const N: usize> Blob<N> {
     }
 
     pub(crate) fn challenge(&self, commitment: &Commitment) -> Fr {
-        let domain = b"FSBLOBVERIFY_V1_";
+        const DOMAIN: &'static [u8; 16] = b"FSBLOBVERIFY_V1_";
         let degree = (N as u128).to_be_bytes();
 
         let comm = commitment.0.serialize();
 
         let mut data = Vec::with_capacity(8 + 16 + Commitment::BYTES + Self::BYTES);
-        data.extend_from_slice(domain);
+        data.extend_from_slice(DOMAIN);
         data.extend_from_slice(&degree);
         for element in self.elements.iter() {
             let bytes = Scalar::from(element).to_be_bytes();

--- a/src/kzg/setup.rs
+++ b/src/kzg/setup.rs
@@ -111,12 +111,12 @@ impl<const G1: usize, const G2: usize> Setup<G1, G2> {
         assert_eq!(commitments.as_ref().len(), points.as_ref().len());
         assert_eq!(points.as_ref().len(), evals.as_ref().len());
 
-        let domain = b"RCKZGBATCH___V1_";
+        const DOMAIN: &'static [u8; 16] = b"RCKZGBATCH___V1_";
         let degree = (G1 as u128).to_be_bytes();
         let len = (proofs.as_ref().len() as u128).to_be_bytes();
 
         let mut data = [0; 48];
-        data[..16].copy_from_slice(domain.as_slice());
+        data[..16].copy_from_slice(DOMAIN.as_slice());
         data[16..32].copy_from_slice(&degree);
         data[32..].copy_from_slice(&len);
 


### PR DESCRIPTION
define the domain used in challenges as `const`.