### PR TITLE
refactor: BRP and G1 MSM

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,7 +1,6 @@
 use crate::{
     bls::{FiniteFieldError, Fr, P1},
     kzg::{Commitment, Polynomial, Proof, Setup},
-    math::BitReversalPermutation,
 };
 
 pub enum Error {
@@ -37,8 +36,7 @@ impl<const N: usize> Blob<N> {
     }
 
     pub(crate) fn commitment<const G2: usize>(&self, setup: &Setup<N, G2>) -> Commitment {
-        let g1_lagrange = BitReversalPermutation::new(setup.g1_lagrange.as_slice());
-        let lincomb = P1::lincomb(g1_lagrange.iter().zip(self.elements.iter()));
+        let lincomb = P1::lincomb(setup.g1_lagrange_brp.as_slice(), self.elements.as_slice());
 
         Commitment::from(lincomb)
     }

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp,
     mem::MaybeUninit,
     ops::{Add, Div, Mul, Neg, Shl, ShlAssign, Shr, ShrAssign, Sub},
 };
@@ -374,21 +375,11 @@ impl P1 {
     }
 
     // TODO: optimize w/ pippenger
-    pub fn lincomb<'a>(terms: impl Iterator<Item = (&'a Self, &'a Fr)>) -> Self {
+    pub fn lincomb(points: impl AsRef<[Self]>, scalars: impl AsRef<[Fr]>) -> Self {
+        let n = cmp::min(points.as_ref().len(), scalars.as_ref().len());
         let mut lincomb = Self::INF;
-        for (point, scalar) in terms {
-            lincomb = lincomb + (point * scalar);
-        }
-
-        lincomb
-    }
-
-    // TODO: optimize w/ pippenger
-    // TODO: unify with `P1::lincomb`
-    pub fn lincomb_owned(terms: impl Iterator<Item = (Self, Fr)>) -> Self {
-        let mut lincomb = Self::INF;
-        for (point, scalar) in terms {
-            lincomb = lincomb + (point * scalar);
+        for i in 0..n {
+            lincomb = lincomb + (points.as_ref()[i] * scalars.as_ref()[i]);
         }
 
         lincomb

--- a/src/kzg/poly.rs
+++ b/src/kzg/poly.rs
@@ -1,7 +1,4 @@
-use crate::{
-    bls::{Fr, P1},
-    math::BitReversalPermutation,
-};
+use crate::bls::{Fr, P1};
 
 use super::{setup::Setup, Proof};
 
@@ -11,7 +8,7 @@ pub(crate) struct Polynomial<'a, const N: usize>(pub(crate) &'a [Fr; N]);
 impl<'a, const N: usize> Polynomial<'a, N> {
     /// evaluates the polynomial at `point`.
     pub(crate) fn evaluate<const G2: usize>(&self, point: Fr, setup: &Setup<N, G2>) -> Fr {
-        let roots = BitReversalPermutation::new(setup.roots_of_unity.as_slice());
+        let roots = &setup.roots_of_unity_brp;
 
         // if `point` is a root of a unity, then we have the evaluation available
         for i in 0..N {
@@ -37,7 +34,7 @@ impl<'a, const N: usize> Polynomial<'a, N> {
 
     /// returns a `Proof` for the evaluation of the polynomial at `point`.
     pub(crate) fn prove<const G2: usize>(&self, point: Fr, setup: &Setup<N, G2>) -> (Fr, Proof) {
-        let roots = BitReversalPermutation::new(setup.roots_of_unity.as_slice());
+        let roots = &setup.roots_of_unity_brp;
 
         let eval = self.evaluate(point, setup);
 
@@ -68,8 +65,7 @@ impl<'a, const N: usize> Polynomial<'a, N> {
             quotient_poly.push(quotient);
         }
 
-        let g1_lagrange = BitReversalPermutation::new(setup.g1_lagrange.as_slice());
-        let lincomb = P1::lincomb(g1_lagrange.iter().zip(quotient_poly.iter()));
+        let lincomb = P1::lincomb(setup.g1_lagrange_brp.as_slice(), quotient_poly);
 
         (eval, lincomb)
     }

--- a/src/kzg/setup.rs
+++ b/src/kzg/setup.rs
@@ -31,9 +31,9 @@ struct SetupUnchecked {
 
 #[derive(Clone, Debug)]
 pub struct Setup<const G1: usize, const G2: usize> {
-    pub(crate) g1_lagrange: Box<[P1; G1]>,
+    pub(crate) g1_lagrange_brp: Box<[P1; G1]>,
     pub(crate) g2_monomial: Box<[P2; G2]>,
-    pub(crate) roots_of_unity: Box<[Fr; G1]>,
+    pub(crate) roots_of_unity_brp: Box<[Fr; G1]>,
 }
 
 impl<const G1: usize, const G2: usize> Setup<G1, G2> {
@@ -63,6 +63,7 @@ impl<const G1: usize, const G2: usize> Setup<G1, G2> {
                 P1::deserialize(point).map_err(|err| LoadSetupError::Bls(BlsError::from(err)))?;
             g1_lagrange[i] = point;
         }
+        let g1_lagrange_brp = math::bit_reversal_permutation_boxed_array(g1_lagrange.as_slice());
 
         let mut g2_monomial: Box<[P2; G2]> = Box::new([P2::default(); G2]);
         for (i, point) in setup.g2_monomial.iter().enumerate() {
@@ -78,13 +79,13 @@ impl<const G1: usize, const G2: usize> Setup<G1, G2> {
             g2_monomial[i] = point;
         }
 
-        let roots_of_unity = math::roots_of_unity();
-        let roots_of_unity = Box::new(roots_of_unity);
+        let roots_of_unity: [Fr; G1] = math::roots_of_unity();
+        let roots_of_unity_brp = math::bit_reversal_permutation_boxed_array(roots_of_unity);
 
         Ok(Setup {
-            g1_lagrange,
+            g1_lagrange_brp,
             g2_monomial,
-            roots_of_unity,
+            roots_of_unity_brp,
         })
     }
 
@@ -110,10 +111,11 @@ impl<const G1: usize, const G2: usize> Setup<G1, G2> {
         assert_eq!(proofs.as_ref().len(), commitments.as_ref().len());
         assert_eq!(commitments.as_ref().len(), points.as_ref().len());
         assert_eq!(points.as_ref().len(), evals.as_ref().len());
+        let n = proofs.as_ref().len();
 
         const DOMAIN: &[u8; 16] = b"RCKZGBATCH___V1_";
         let degree = (G1 as u128).to_be_bytes();
-        let len = (proofs.as_ref().len() as u128).to_be_bytes();
+        let len = (n as u128).to_be_bytes();
 
         let mut data = [0; 48];
         data[..16].copy_from_slice(DOMAIN.as_slice());
@@ -121,28 +123,25 @@ impl<const G1: usize, const G2: usize> Setup<G1, G2> {
         data[32..].copy_from_slice(&len);
 
         let r = Fr::hash_to(data);
-        let mut rpowers = Vec::with_capacity(proofs.as_ref().len());
+        let mut rpowers = Vec::with_capacity(n);
+        let mut points_mul_rpowers = Vec::with_capacity(n);
+        let mut comms_minus_evals = Vec::with_capacity(n);
         for i in 0..proofs.as_ref().len() {
-            rpowers.push(r.pow(&Fr::from(i as u64)));
+            let rpower = r.pow(&Fr::from(i as u64));
+            rpowers.push(rpower);
+
+            let point = points.as_ref()[i];
+            points_mul_rpowers.push(point * rpower);
+
+            let commitment = commitments.as_ref()[i];
+            let eval = evals.as_ref()[i];
+            comms_minus_evals.push(commitment + (P1::neg_generator() * eval));
         }
 
-        let proof_lincomb = P1::lincomb(proofs.as_ref().iter().zip(rpowers.iter()));
-        let proof_z_lincomb = P1::lincomb_owned(
-            proofs.as_ref().iter().copied().zip(
-                points
-                    .as_ref()
-                    .iter()
-                    .zip(rpowers.iter())
-                    .map(|(point, pow)| point * pow),
-            ),
-        );
+        let proof_lincomb = P1::lincomb(&proofs, &rpowers);
+        let proof_z_lincomb = P1::lincomb(proofs, points_mul_rpowers);
 
-        let comm_minus_eval = commitments
-            .as_ref()
-            .iter()
-            .zip(evals.as_ref().iter())
-            .map(|(comm, eval)| *comm + (P1::neg_generator() * eval));
-        let comm_minus_eval_lincomb = P1::lincomb_owned(comm_minus_eval.zip(rpowers));
+        let comm_minus_eval_lincomb = P1::lincomb(comms_minus_evals, rpowers);
 
         bls::verify_pairings(
             (proof_lincomb, self.g2_monomial[1]),


### PR DESCRIPTION
refactor bit-reversal permutation (BRP) and multi-scalar multiplication (MSM) for G1.

we include the following changes:

* modify `P1::lincomb` parameters from an iterator of tuples (i.e. pairs) to two separate slices
* remove `P1::lincomb_owned`
* remove `BitReversalPermutation` and `BitReversalPermutationIter`
* add BRP functions that return the BRP of the input
* modify `Setup` to hold G1 Lagrange points and roots of unity in BRP