### PR TITLE
ci: add flag to fail on warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,4 @@ jobs:
     - name: format
       run: cargo fmt --all --check
     - name: clippy
-      run: cargo clippy --all --all-targets --all-features --verbose
+      run: cargo clippy --all --all-targets --all-features --verbose -- -D warnings


### PR DESCRIPTION
add `-D warnings` to CI `clippy` command.