### PR TITLE
perf: add G1 pippenger MSM

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -36,7 +36,8 @@ impl<const N: usize> Blob<N> {
     }
 
     pub(crate) fn commitment<const G2: usize>(&self, setup: &Setup<N, G2>) -> Commitment {
-        let lincomb = P1::lincomb(setup.g1_lagrange_brp.as_slice(), self.elements.as_slice());
+        let lincomb =
+            P1::lincomb_pippenger(setup.g1_lagrange_brp.as_slice(), self.elements.as_slice());
 
         Commitment::from(lincomb)
     }

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -1,3 +1,4 @@
+use core::slice;
 use std::{
     cmp,
     mem::MaybeUninit,
@@ -8,12 +9,12 @@ use blst::{
     blst_bendian_from_scalar, blst_final_exp, blst_fp, blst_fp12, blst_fp12_is_one, blst_fp12_mul,
     blst_fr, blst_fr_add, blst_fr_cneg, blst_fr_eucl_inverse, blst_fr_from_scalar,
     blst_fr_from_uint64, blst_fr_lshift, blst_fr_mul, blst_fr_rshift, blst_fr_sub,
-    blst_miller_loop, blst_p1, blst_p1_add, blst_p1_affine, blst_p1_affine_in_g1, blst_p1_cneg,
-    blst_p1_compress, blst_p1_deserialize, blst_p1_from_affine, blst_p1_mult, blst_p1_to_affine,
-    blst_p2, blst_p2_add, blst_p2_affine, blst_p2_affine_in_g2, blst_p2_deserialize,
-    blst_p2_from_affine, blst_p2_mult, blst_p2_to_affine, blst_scalar, blst_scalar_fr_check,
-    blst_scalar_from_bendian, blst_scalar_from_fr, blst_sha256, blst_uint64_from_fr, BLS12_381_G2,
-    BLS12_381_NEG_G1, BLS12_381_NEG_G2, BLST_ERROR,
+    blst_lendian_from_scalar, blst_miller_loop, blst_p1, blst_p1_add, blst_p1_affine,
+    blst_p1_affine_in_g1, blst_p1_cneg, blst_p1_compress, blst_p1_deserialize, blst_p1_from_affine,
+    blst_p1_mult, blst_p1_to_affine, blst_p2, blst_p2_add, blst_p2_affine, blst_p2_affine_in_g2,
+    blst_p2_deserialize, blst_p2_from_affine, blst_p2_mult, blst_p2_to_affine, blst_scalar,
+    blst_scalar_fr_check, blst_scalar_from_bendian, blst_scalar_from_fr, blst_sha256,
+    blst_uint64_from_fr, p1_affines, BLS12_381_G2, BLS12_381_NEG_G1, BLS12_381_NEG_G2, BLST_ERROR,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -116,6 +117,16 @@ impl Fr {
         unsafe {
             blst_scalar_from_fr(scalar.as_mut_ptr(), &self.element);
             blst_bendian_from_scalar(bytes.as_mut_ptr(), scalar.as_ptr());
+        }
+        bytes
+    }
+
+    pub fn to_le_bytes(self) -> [u8; Self::BYTES] {
+        let mut bytes = [0; Self::BYTES];
+        let mut scalar = MaybeUninit::<blst_scalar>::uninit();
+        unsafe {
+            blst_scalar_from_fr(scalar.as_mut_ptr(), &self.element);
+            blst_lendian_from_scalar(bytes.as_mut_ptr(), scalar.as_ptr());
         }
         bytes
     }
@@ -322,6 +333,7 @@ impl Shr<usize> for Fr {
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(transparent)]
 pub struct P1 {
     element: blst_p1,
 }
@@ -374,15 +386,34 @@ impl P1 {
         out
     }
 
-    // TODO: optimize w/ pippenger
     pub fn lincomb(points: impl AsRef<[Self]>, scalars: impl AsRef<[Fr]>) -> Self {
         let n = cmp::min(points.as_ref().len(), scalars.as_ref().len());
-        let mut lincomb = Self::INF;
+        let mut lincomb = P1::INF;
         for i in 0..n {
             lincomb = lincomb + (points.as_ref()[i] * scalars.as_ref()[i]);
         }
-
         lincomb
+    }
+
+    pub fn lincomb_pippenger(points: impl AsRef<[Self]>, scalars: impl AsRef<[Fr]>) -> Self {
+        let n = cmp::min(points.as_ref().len(), scalars.as_ref().len());
+
+        let points = unsafe {
+            slice::from_raw_parts(
+                points.as_ref().as_ptr() as *const blst_p1,
+                points.as_ref().len(),
+            )
+        };
+        let points = p1_affines::from(points);
+
+        let mut scalar_bytes = Vec::with_capacity(scalars.as_ref().len() * Fr::BYTES);
+        for i in 0..n {
+            scalar_bytes.extend_from_slice(scalars.as_ref()[i].to_le_bytes().as_slice());
+        }
+
+        let lincomb = points.mult(&scalar_bytes, 255);
+
+        Self { element: lincomb }
     }
 
     // TODO: make available as `const`

--- a/src/kzg/poly.rs
+++ b/src/kzg/poly.rs
@@ -65,7 +65,7 @@ impl<'a, const N: usize> Polynomial<'a, N> {
             quotient_poly.push(quotient);
         }
 
-        let lincomb = P1::lincomb(setup.g1_lagrange_brp.as_slice(), quotient_poly);
+        let lincomb = P1::lincomb_pippenger(setup.g1_lagrange_brp.as_slice(), quotient_poly);
 
         (eval, lincomb)
     }


### PR DESCRIPTION
add method for pippenger MSM in G1 group.

NOTE: we employ the pippenger MSM in commitment and proof generation, but not proof verification. the `blst` pippenger code remains unaudited at the time of writing.