### PR TITLE
chore: add clippy lint to use 'core' when available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,4 @@ jobs:
     - name: format
       run: cargo fmt --all --check
     - name: clippy
-      run: cargo clippy --all --all-targets --all-features --verbose -- -D warnings
+      run: cargo clippy --all --all-targets --all-features --verbose -- -W clippy::std_instead_of_core -D warnings

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -1,8 +1,8 @@
-use core::slice;
-use std::{
+use core::{
     cmp,
     mem::MaybeUninit,
     ops::{Add, Div, Mul, Neg, Shl, ShlAssign, Shr, ShrAssign, Sub},
+    slice,
 };
 
 use blst::{

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::bls::Fr;
 


### PR DESCRIPTION
add `clippy` lint to use `core` instead of `std` in a move toward `no_std` compatibility.