### PR TITLE
refactor: add byte array type for deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-primitives = { version = "0.4.2", features = ["std", "serde"] }
 blst = "0.3.11"
 criterion = "0.5.1"
+hex = "0.4.3"
 rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,0 +1,52 @@
+use serde::{de::Visitor, Deserialize};
+
+#[derive(Clone, Debug)]
+pub struct Bytes(Vec<u8>);
+
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+pub struct BytesVisitor;
+
+impl<'de> Visitor<'de> for BytesVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str(
+            "a variable-length byte array represented by a raw byte array or a hex-encoded string",
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let v = v.strip_prefix("0x").unwrap_or(v);
+        let v = hex::decode(v).map_err(E::custom)?;
+        Ok(v)
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let v = hex::decode(v).map_err(E::custom)?;
+        Ok(v)
+    }
+}
+
+impl<'de> Deserialize<'de> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(BytesVisitor).map(Bytes)
+        } else {
+            deserializer.deserialize_bytes(BytesVisitor).map(Bytes)
+        }
+    }
+}

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -14,7 +14,7 @@ pub struct BytesVisitor;
 impl<'de> Visitor<'de> for BytesVisitor {
     type Value = Vec<u8>;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str(
             "a variable-length byte array represented by a raw byte array or a hex-encoded string",
         )

--- a/src/kzg/spec.rs
+++ b/src/kzg/spec.rs
@@ -1,18 +1,20 @@
-use alloy_primitives::{Bytes, FixedBytes};
 use serde::Deserialize;
 
-use crate::bls::{Fr, P1};
+use crate::{
+    bls::{Fr, P1},
+    bytes::Bytes,
+};
 
 use super::{Bytes32, Bytes48};
 
 fn bytes32_from_bytes(bytes: &Bytes) -> Option<Bytes32> {
-    let bytes = FixedBytes::<{ Fr::BYTES }>::try_from(bytes.as_ref()).ok();
+    let bytes: Option<[u8; Fr::BYTES]> = TryFrom::try_from(bytes.as_ref()).ok();
     bytes.map(Into::<Bytes32>::into)
 }
 
 fn bytes48_from_bytes(bytes: &Bytes) -> Option<Bytes48> {
-    let bytes = FixedBytes::<{ P1::BYTES }>::try_from(bytes.as_ref()).ok()?;
-    Some(bytes.into())
+    let bytes: Option<[u8; P1::BYTES]> = TryFrom::try_from(bytes.as_ref()).ok();
+    bytes.map(Into::<Bytes48>::into)
 }
 
 #[derive(Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod bls;
+mod bytes;
 mod math;
 
 pub use bls::{Compress, Decompress};


### PR DESCRIPTION
add `Bytes` type for deserialization and remove dependency on `alloy-primitives`.