### PR TITLE
chore: move 'criterion' to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 blst = "0.3.11"
-criterion = "0.5.1"
 hex = "0.4.3"
 rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.189", features = ["derive"] }
@@ -13,6 +12,7 @@ serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 
 [dev-dependencies]
+criterion = "0.5.1"
 rand = "0.8.5"
 
 [features]


### PR DESCRIPTION
move `criterion` to `dev-dependencies` in `Cargo.toml`.