### PR TITLE
fix: update cfg attribute for serde feature

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -7,7 +7,7 @@ impl AsRef<[u8]> for Bytes {
     }
 }
 
-#[cfg(any(test, feature = "serde"))]
+#[cfg(feature = "serde")]
 pub mod serde {
     use super::*;
 

--- a/src/kzg/mod.rs
+++ b/src/kzg/mod.rs
@@ -3,7 +3,7 @@ use crate::{blob, bls};
 mod poly;
 mod setup;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 mod spec;
 
 pub type Proof = bls::P1;


### PR DESCRIPTION
fix `cfg` attribute for `serde` feature introduced in #48.

without this change, the invocation of a `cargo` target would fail if the `--all-features` flag was not present.